### PR TITLE
Change ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Steps for running locally:
 
 ## To Do
 * Investigate whether filename can be made of variables used to create the maze in question e.g. recording corridor size etc.
+* Improve copying of SmartGrid as it goes into the solver, current approach is not ideal (two SmartGrid instances sharing data for their `cells` values)
 * Restructure project to make it more idiomatic, misc. code tidying e.g. removing unused code
 * Allow `cli_display()` to be triggered from the command line, update docs accordingly
 * Address bugs that happen when width is set to more than one greater value than height

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Steps for running locally:
 
 
 ## To Do
+* Investigate whether filename can be made of variables used to create the maze in question e.g. recording corridor size etc.
 * Restructure project to make it more idiomatic, misc. code tidying e.g. removing unused code
 * Allow `cli_display()` to be triggered from the command line, update docs accordingly
 * Address bugs that happen when width is set to more than one greater value than height

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,6 @@ impl Default for Settings {
         }
     }
 }
-
 type SolvedMaze = Option<SmartGrid>;
 #[derive(PartialEq, Debug, Copy, Clone, Default)]
 enum Algos {
@@ -74,6 +73,7 @@ fn prepare_grid(columns: usize, rows: usize) -> SmartGrid {
         rows,
         columns,
         cells: Vec::new(),
+        max_distance: 0,
     };
     grid.cells = grid.prepare_grid();
     grid.configure_cells();

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,10 +137,10 @@ fn update(_app: &App, model: &mut Model, update: Update) {
 
             ui.separator();
             ui.label("Height:");
-            ui.add(egui::Slider::new(&mut settings.height, 2.0..=50.0));
+            ui.add(egui::Slider::new(&mut settings.height, 2.0..=100.0));
 
             ui.label("Width:");
-            ui.add(egui::Slider::new(&mut settings.width, 2.0..=50.0));
+            ui.add(egui::Slider::new(&mut settings.width, 2.0..=100.0));
 
             ui.label("Corridor size");
             ui.add(egui::Slider::new(&mut settings.corridor_size, 0.1..=100.0));

--- a/src/maze/core.rs
+++ b/src/maze/core.rs
@@ -68,6 +68,7 @@ pub struct SmartGrid {
     pub rows: usize,
     pub columns: usize,
     pub cells: Vec<Vec<Rc<RefCell<MazeCell>>>>,
+    pub max_distance: usize,
 }
 
 impl SmartGrid {

--- a/src/maze/render.rs
+++ b/src/maze/render.rs
@@ -1,4 +1,4 @@
-use crate::maze::core::{Direction, MazeCell};
+use crate::maze::core::{Direction, MazeCell, SmartGrid};
 use crate::Model;
 use nannou::color::{rgb8, Rgb8};
 use nannou::geom::pt2;
@@ -65,6 +65,13 @@ pub fn calculate_origin(columns: f32, rows: f32, cell_size: f32) -> Point {
 }
 pub fn draw_maze(model: &Model, draw: &Draw, colours: WallColours) {
     let is_solved = model.solved_maze.is_some();
+    let mut max_distance = 1;
+    if is_solved {
+        max_distance = <Option<SmartGrid> as Clone>::clone(&model.solved_maze)
+            .unwrap()
+            .max_distance;
+    }
+
     let line_weight = model.settings.walls.width;
     for row in &model.maze.cells {
         for cell in row.iter() {
@@ -92,10 +99,9 @@ pub fn draw_maze(model: &Model, draw: &Draw, colours: WallColours) {
             let draw_west = cell.west.is_none();
             let draw_east = !MazeCell::is_linked_to(&cell, Direction::East);
             let draw_south = !MazeCell::is_linked_to(&cell, Direction::South);
-            let distance = cell.distance as f32;
             if is_solved {
                 draw.quad()
-                    .rgb8(1, 2, ((distance + 1.0) * 2.0) as u8)
+                    .rgb8(1, 2, ((255 / max_distance) * cell.distance) as u8)
                     .points(
                         north_west_point,
                         north_east_point,

--- a/src/maze/solve.rs
+++ b/src/maze/solve.rs
@@ -15,7 +15,6 @@ pub fn dijkstra_simplified_solver(mut grid: SmartGrid) -> SmartGrid {
         for location in frontier.iter().copied() {
             let Location { row, column } = location;
             let mut current_cell = grid.cells.index_mut(row).index_mut(column).borrow_mut();
-
             current_cell.distance = distance;
             next_frontier.extend(Vec::from_iter(current_cell.links.iter()));
             visited.extend([location]);
@@ -24,6 +23,6 @@ pub fn dijkstra_simplified_solver(mut grid: SmartGrid) -> SmartGrid {
         frontier = next_frontier.difference(&visited).copied().collect();
         distance += 1;
     }
-
+    grid.max_distance = distance;
     grid
 }

--- a/src/sidewinder_hardcoded.rs
+++ b/src/sidewinder_hardcoded.rs
@@ -196,5 +196,6 @@ pub fn static_sidewinder() -> SmartGrid {
                 })),
             ],
         ],
+        max_distance: 0,
     }
 }


### PR DESCRIPTION
Fix relationship between blue saturation and a cell's distance value.
Now the furthest away cell should always have pretty much 255 blue saturation, irrespective of maze size.

Previously the larger the maze, the more saturation the furthest away cell would have. This meant that small mazes, when solved, were quite difficult to see the solver results, because the everything was quite dark.

This PR also allows for larger mazes to be made.